### PR TITLE
Fix freeze when triggering window switcher

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -33,6 +33,7 @@ class Plugin(PluginInstance, TriggerQueryHandler):
         return 'w '
 
     def handleTriggerQuery(self, query):
+        results = []
         try:
             for line in subprocess.check_output(['wmctrl', '-l', '-x']).splitlines():
                 win = Window(*parseWindow(line))
@@ -44,7 +45,7 @@ class Plugin(PluginInstance, TriggerQueryHandler):
 
                 m = Matcher(query.string)
                 if not query.string or m.match(win_instance + ' ' + win_class + ' ' + win.wm_name):
-                    query.add(StandardItem(
+                    results.append(StandardItem(
                         id="%s%s" % (md_name, win.wm_class),
                         iconUrls=["xdg:%s" % win_instance],
                         text="%s  - Desktop %s" % (win_class.replace('-', ' '), win.desktop),
@@ -61,7 +62,7 @@ class Plugin(PluginInstance, TriggerQueryHandler):
                     ))
         except subprocess.CalledProcessError as e:
             warning(f"Error executing wmctrl: {str(e)}")
-
+        query.add(results)
 
 def parseWindow(line):
     win_id, desktop, rest = line.decode().split(None, 2)


### PR DESCRIPTION
Ran into a similar problem to the freezing described in [#215](https://github.com/albertlauncher/python/issues/215) when attempting to use the X Window Switcher plugin. When typing after triggering the window switcher, Albert becomes unresponsive and ultimately has to be killed.

I've applied [the fix](https://github.com/albertlauncher/python/pull/221) for the freezing bitwarden plugin to the window switcher, which resolved the instability. Instead of calling `query.add` in a loop, this version accumulates results in a list and only calls `add` one time.